### PR TITLE
Adds no_terminal_background option

### DIFF
--- a/colors/afterglow.vim
+++ b/colors/afterglow.vim
@@ -539,11 +539,19 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
     if !exists( "g:afterglow_blackout")
         let g:afterglow_blackout = 0
     endif
+    if !exists( "g:afterglow_no_terminal_background")
+        let g:afterglow_no_terminal_background = 0
+    endif
     if g:afterglow_blackout
         let s:chosen_background = s:black
     else
         let s:chosen_background = s:background
     endif
+    if g:afterglow_no_terminal_background
+                \ && !has("gui_running") && !exists('g:GtkGuiLoaded')
+        let s:chosen_background = ""
+    endif
+
     " Settings dependent on g:afterglow_blackout
     call <SID>X("Normal", s:foreground, s:chosen_background, "")
     call <SID>X("LineNr", s:comment, s:chosen_background, "")

--- a/colors/afterglow.vim
+++ b/colors/afterglow.vim
@@ -548,7 +548,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
         let s:chosen_background = s:background
     endif
     if g:afterglow_no_terminal_background
-                \ && !has("gui_running") && !exists('g:GtkGuiLoaded')
+                \ && !has("gui_running") && !exists("g:GtkGuiLoaded")
         let s:chosen_background = ""
     endif
 


### PR DESCRIPTION
I don't know if you want this, but it's useful for me :)

This adds `g:afterglow_no_terminal_background` option, defaults to 0.
If set to 1, then the background terminal color won't be changed by the colorscheme.

It checks if we're not running gvim or neovim-gtk. Maybe there are some other gui clients to check.

This is useful, for example, for tmux users that change the background for the active pane (like me :))

![2019-06-21-105944_1330x705_scrot](https://user-images.githubusercontent.com/12790724/59932044-55b9af80-9414-11e9-844c-5d01a0c06ccf.png)


Tested with vim/gvim 8.1, neovim v0.3.7, neovim-gtk 0.2.0