### PR TITLE
Adapting the helper method seems better after all

### DIFF
--- a/colors/afterglow.vim
+++ b/colors/afterglow.vim
@@ -230,12 +230,19 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 
     " Sets the highlighting for the given group
     fun <SID>X(group, fg, bg, attr)
-        " NOTE: this function is evidently not adapted to named colors, nor 'none' (cf. issue #13)
         if a:fg != ""
-            exec "hi " . a:group . " guifg=#" . a:fg . " ctermfg=" . <SID>rgb(a:fg)
+            if a:fg == "none"
+                exec "hi " . a:group . " guifg=none ctermfg=none"
+            else
+                exec "hi " . a:group . " guifg=#" . a:fg . " ctermfg=" . <SID>rgb(a:fg)
+            endif
         endif
         if a:bg != ""
-            exec "hi " . a:group . " guibg=#" . a:bg . " ctermbg=" . <SID>rgb(a:bg)
+            if a:bg == "none"
+                exec "hi " . a:group . " guibg=none ctermbg=none"
+            else
+                exec "hi " . a:group . " guibg=#" . a:bg . " ctermbg=" . <SID>rgb(a:bg)
+            endif
         endif
         if a:attr != ""
             exec "hi " . a:group . " gui=" . a:attr . " cterm=" . a:attr
@@ -548,11 +555,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 
     " Background behavior inference here:
     if g:afterglow_inherit_background
-        " Avoiding 'none' as <SID>X is not prepared to receive named colors
-        " Instead, using the empty string so that we skip highlighting this group's background
-        " The cleared version of the background is indeed what we expect from 'inheriting' from the environment.
-        " It respects transparency, adapts on the fly and so on. Not sure about tmux compatibility though.
-        let s:chosen_background = ""
+        let s:chosen_background = "none"
     elseif g:afterglow_blackout
         let s:chosen_background = s:black
     else


### PR DESCRIPTION
- Previously patch had unintended consequences on the way
  some groups are highlighted, since cleared (default) behavior for
  some highlight groups are weird in this colorscheme (yellow background
  for TODO and so on)